### PR TITLE
Fix typo in setup comment

### DIFF
--- a/QueenFX.ino
+++ b/QueenFX.ino
@@ -15,7 +15,7 @@ const byte numStrips = 16;
 CRGB leds[numStrips][longestTube];
 
 // I'm using the teensy 3.2 with 16 pins (DMA)
-// I'm not using 3 of the pins, but I'm keeping this retangular for ease of thinking
+// I'm not using 3 of the pins, but I'm keeping this rectangular for ease of thinking
 const byte numVirtualStrips = 16;
 CRGB realLeds[numVirtualStrips][ledCount];
 


### PR DESCRIPTION
## Summary
- fix a typo in a comment so it says "rectangular" instead of "retangular"

## Testing
- `grep -n "rectangular" -n QueenFX.ino`


------
https://chatgpt.com/codex/tasks/task_e_683d06fc2e54832ba8dc834bb92482b7